### PR TITLE
Fix custom stations

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -139,7 +139,7 @@ class RadioApi():
         if self.__check_paylist(stream_url):
             return self.__resolve_playlist(station)
         else:
-            return station
+            return stream_url
 
     def get_top_stations(self, sizeperpage, pageindex):
         self.log(('get_top_stations started with '


### PR DESCRIPTION
Since "678b32e - Use the playlist resolver also in custom stations"
selecting a custom station will result in an error if its URL is not a
playlist.